### PR TITLE
Fix routes that may match on params early and fail later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
+- 'node'
 - '0.11'
 - '0.10'
-- '0.8'
-- '0.6'

--- a/lib/router.js
+++ b/lib/router.js
@@ -46,30 +46,41 @@ function Router(req , res) {
         return notFound(req, res)
     }
 
-    //Clear the request parameters holder
-    req.params = {}
+    var paramsHolder = []
+
+    var cursor = 0
+
+    var lastTrueTableMatch = table
+    var lastTrueCursorMatch = cursor
+    var nextParamsMatchIndex = []
 
     //Start iterating throught the routing tree
     continue_to_next_value:
-    for(var i = 0; i < size; i++) {
+    while(cursor < size) {
         //Vars
-        var value = paths[i] //The part of the path we are currently working with
+        var value = paths[cursor] //The part of the path we are currently working with
 
         //First try matching with the hashtable with base paths
         var base = table.bases[value]
 
         //Check if some base path was matched
         if(typeof base !== 'undefined') {
-            table = base //recurse into
+            cursor++
+            table = base
+            lastTrueTableMatch = base
+            lastTrueCursorMatch = cursor
+            lastParamsMatchIndex = 0
             continue //to next match
         }
-        //Else, check the parameters table
-        else if(table.params.length > 0) {
-            var params = table.params
 
-            for(var p in params) {
-                var key  = params[p].param
-                var rule = params[p].regexp
+        //Else, check the parameters table
+        var params = table.params
+        var paramsIndex = nextParamsMatchIndex[cursor] || 0
+
+        if(params.length > 0) {
+            for(; paramsIndex < params.length; paramsIndex++) {
+                var key  = params[paramsIndex].param
+                var rule = params[paramsIndex].regexp
 
                 if(typeof rule !== 'undefined') {
                     if(rule.test(value) === false) {
@@ -78,13 +89,36 @@ function Router(req , res) {
                 }
 
                 //If we got here, we found a possible parameter :)
-                req.params[key] = value
-                table = params[p].routes //recurse into
+                paramsHolder[cursor] = { key: key, value: value }
+                cursor++
+                table = params[paramsIndex].routes //recurse into
                 continue continue_to_next_value //Break to next part of the paths
             }
         }
 
+        if(lastTrueTableMatch) {
+            table = lastTrueTableMatch
+            cursor = lastTrueCursorMatch
+            nextParamsMatchIndex[cursor] = (nextParamsMatchIndex[cursor] || 0) + 1
+
+            if(! table.params[nextParamsMatchIndex[cursor]]) {
+                lastTrueTableMatch = null
+                lastTrueCursorMatch = null
+            }
+
+            continue continue_to_next_value
+        }
+
         return notFound(req, res)
+    }
+
+    // Map found params to req.params holder
+    req.params = {}
+
+    for(var i in paramsHolder) {
+        var param = paramsHolder[i]
+
+        req.params[param.key] = param.value
     }
 
     //If we are here, the dynamicRoutes algorithm must have found a route

--- a/test/test-router.js
+++ b/test/test-router.js
@@ -134,6 +134,31 @@ exports.testNotFound = function(test) {
     TestReqTo('GET', '/this/route/should/not/exist')
 }
 
+// Test multiple routes with same params prefix
+// Addresses issue:
+// https://github.com/herenow/light-router/issues/2
+exports.testMultipleRoutesSameParamsPrefix = function(test) {
+    test.expect(6)
+
+    router.get('/multipleRoutesSamePrefix/:id/:second_id/users', function(req, res) {
+        test.equal(req.params.id, 'joana', 'data param did not match')
+        test.equal(req.params.second_id, 'jejezki', 'data param did not match')
+    })
+    router.get('/multipleRoutesSamePrefix/:id/:second_id/places', function(req, res) {
+        test.equal(req.params.id, 'home', 'data param did not match')
+        test.equal(req.params.second_id, 'depot', 'data param did not match')
+    })
+    router.get('/multipleRoutesSamePrefix/:id/:second_id/jobs', function(req, res) {
+        test.equal(req.params.id, 'apple', 'data param did not match')
+        test.equal(req.params.second_id, 'california', 'data param did not match')
+        test.done()
+    })
+
+    TestReqTo('GET', '/multipleRoutesSamePrefix/joana/jejezki/users')
+    TestReqTo('GET', '/multipleRoutesSamePrefix/home/depot/places')
+    TestReqTo('GET', '/multipleRoutesSamePrefix/apple/california/jobs')
+}
+
 //Display routing table final
 exports.testRoutingTable = function(test) {
     var table = router.routingTable()


### PR DESCRIPTION
Fixes issue #2

[Bug]

Whenever we had a value from the path that would match a parameter, we
would immediately recurse into the next routing table. This is a
problem, because a routing table may contain multiple params, and we
don't really know if the table we just recursed into, will continue to
match later on, it mail not match when it encounters a regexp or base
path.

For example:

If we have this two routes:

`/:id/:second_id/users`
`/:id/:second_id/places`

The second route would never match, on a path such as:

`/123/123/places`

Since we would always match on the first route, and fail on the last
part of the path.

[Solution]

Save the last real table match in a temporary variable.

A "real table match" is any match that was performed on a "base" path,
since params may match any path, but may will later fail if any base
path does not match, thus we need to go back in the routing tree and try
the next param on the last table we had a "real" match.

[Notes]

I'm not satisfied with our code, we are maintaining way too much state,
we should probably write a more "functional" code, and write a recursive
function instead of retaining state in variables, but this will probably
affect our performance promises (although I don't really care anymore)....
